### PR TITLE
Fix formatting of .pre-commit-config.yaml

### DIFF
--- a/python_seed/template/module/.pre-commit-config.yaml
+++ b/python_seed/template/module/.pre-commit-config.yaml
@@ -40,5 +40,5 @@ repos:
         repo: https://github.com/pre-commit/mirrors-mypy
         rev: 'v0.782'
         hooks:
-            -   id: mypy
-                args: [--no-strict-optional, --ignore-missing-imports]s
+            - id: mypy
+              args: ['--no-strict-optional', '--ignore-missing-imports']


### PR DESCRIPTION
On  my python-seed generated project, the github ci action was failing for python 3.7 in the pre-commit, because of a parsing problem.